### PR TITLE
Do not crash when a rule can't be found for some reason. Could not re…

### DIFF
--- a/niddler-plugin/src/main/kotlin/com/chimerapps/niddler/ui/debugging/rewrite/RewriteDialog.kt
+++ b/niddler-plugin/src/main/kotlin/com/chimerapps/niddler/ui/debugging/rewrite/RewriteDialog.kt
@@ -137,6 +137,7 @@ class RewriteDialog(parent: Window?, project: Project) : JDialog(parent, "Rewrit
 
     private fun onItemUpdated(old: RewriteSet, new: RewriteSet) {
         val oldIndex = rules.indexOf(old)
+        if (oldIndex < 0) return
         rules[oldIndex] = new
         masterPanel.rewriteSetUpdated(oldIndex, new)
     }


### PR DESCRIPTION
…produce, but at least don't crash.

Fixes #13